### PR TITLE
Add chat session and feedback API endpoints

### DIFF
--- a/server/src/controllers/chat.controller.ts
+++ b/server/src/controllers/chat.controller.ts
@@ -1,0 +1,93 @@
+import { Response } from "express";
+import type { AuthRequest } from "../middlewares/auth.middleware";
+import Session from "../models/Session";
+import {
+  getChatCompletion,
+  generateFeedbackAnalysis,
+} from "../services/OpenAIService";
+
+export const startSession = async (req: AuthRequest, res: Response) => {
+  try {
+    const { scenario, role, difficultyLevel } = req.body;
+    const userId = req.user._id;
+    // System Prompt: Botun karakterini tanımlıyoruz
+    const systemMessage = {
+      role: "system",
+      content: `You are a ${role} in a ${scenario}. The user is learning English at ${difficultyLevel} level. 
+        Roleplay with them. Be immersive. Don't correct grammar yet. Keep responses short (1-3 sentences).`,
+    };
+
+    const newSession = await Session.create({
+      userId,
+      scenario,
+      role,
+      difficultyLevel,
+      messages: [systemMessage],
+    });
+    res.status(201).send(newSession);
+  } catch (error) {
+    res.status(500).json({ message: "Internal server error" });
+    console.error("Error in startSession controller:", error);
+  }
+};
+export const sendMessage = async (req: AuthRequest, res: Response) => {
+  try {
+    const { sessionId, message } = req.body;
+    const session = await Session.findOne({
+      _id: sessionId,
+      userId: req.user._id,
+    });
+    if (!session || session.status === "completed") {
+      return res
+        .status(404)
+        .json({ message: "Session not found or completed" });
+    }
+    session.messages.push({
+      role: "user",
+      content: message,
+      timestamp: new Date(),
+    });
+    const historyForAI = session.messages.map((msg) => ({
+      role: msg.role as "system" | "user" | "assistant",
+      content: msg.content,
+    }));
+    const aiResponse = await getChatCompletion(historyForAI);
+    if (aiResponse) {
+      session.messages.push({
+        role: "assistant",
+        content: aiResponse,
+        timestamp: new Date(),
+      });
+    }
+    await session.save();
+    res.json({ reply: aiResponse });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Message failed" });
+  }
+};
+export const endSession = async (req: AuthRequest, res: Response) => {
+  try {
+    const { sessionId } = req.body;
+    const session = await Session.findOne({
+      _id: sessionId,
+      userId: req.user._id,
+    });
+    if (!session) {
+      return res.status(404).json({ message: "Session not found" });
+    }
+    const feedback = await generateFeedbackAnalysis(session.messages);
+    if (!feedback) {
+      return res
+        .status(500)
+        .json({ message: "Failed to parse feedback from AI" });
+    }
+    session.feedback = feedback;
+    session.status = "completed";
+    await session.save();
+    res.json(feedback);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to generate feedback" });
+  }
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,14 +2,16 @@ import express from "express";
 import { connectDB } from "./config/db";
 import cors from "cors";
 import userRoutes from "./routes/user.route";
+import chatRoutes from "./routes/chat.route";
 const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(cors());
-app.use("/api/users",userRoutes);
+app.use("/api/users", userRoutes);
+app.use("/api/chat", chatRoutes);
 
-app.listen(PORT,()=>{
-    console.log(`Server is running on port ${PORT}`)
-    connectDB();
-})
+app.listen(PORT, () => {
+  console.log(`Server is running on port ${PORT}`);
+  connectDB();
+});

--- a/server/src/models/Session.ts
+++ b/server/src/models/Session.ts
@@ -1,0 +1,71 @@
+import mongoose, { Schema, Document } from "mongoose";
+
+interface IMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+  timestamp: Date;
+}
+
+interface IFeedback {
+  score: number; // 100 üzerinden
+  grammarMistakes: Array<{
+    original: string;
+    correction: string;
+    explanation: string;
+  }>;
+  vocabularySuggestions: string[];
+  overallComment: string;
+}
+export interface ISession extends Document {
+  userId: mongoose.Types.ObjectId; // Hangi kullanıcı?
+  scenario: string; // Örn: "Coffee Shop"
+  role: string; // Örn: "Barista"
+  difficultyLevel: string; // Örn: "B1"
+  status: "active" | "completed";
+  messages: IMessage[];
+  feedback?: IFeedback; // Başta boş, bitince dolacak
+  createdAt: Date;
+}
+
+const sessionSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+    },
+    scenario: { type: String, required: true },
+    role: { type: String, required: true },
+    difficultyLevel: { type: String, required: true },
+    status: { type: String, enum: ["active", "completed"], default: "active" },
+
+    messages: [
+      {
+        role: {
+          type: String,
+          enum: ["system", "user", "assistant"],
+          required: true,
+        },
+        content: { type: String, required: true },
+        timestamp: { type: Date, default: Date.now },
+      },
+    ],
+
+    feedback: {
+      score: Number,
+      grammarMistakes: [
+        {
+          original: String,
+          correction: String,
+          explanation: String,
+        },
+      ],
+      vocabularySuggestions: [String],
+      overallComment: String,
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+export default mongoose.model<ISession>("Session", sessionSchema);

--- a/server/src/routes/chat.route.ts
+++ b/server/src/routes/chat.route.ts
@@ -1,0 +1,16 @@
+import express from "express";
+
+import { protect } from "../middlewares/auth.middleware";
+import {
+  endSession,
+  sendMessage,
+  startSession,
+} from "../controllers/chat.controller";
+
+const router = express.Router();
+
+router.post("/start", protect, startSession);
+router.post("/message", protect, sendMessage);
+router.post("/end", protect, endSession);
+
+export default router;

--- a/server/src/services/OpenAIService.ts
+++ b/server/src/services/OpenAIService.ts
@@ -1,0 +1,48 @@
+import OpenAI from "openai";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+
+export const getChatCompletion = async (history: any[]) => {
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: history,
+    temperature: 0.7,
+    max_tokens: 150,
+  });
+
+  return completion.choices[0].message.content;
+};
+
+export const generateFeedbackAnalysis = async (conversationHistory: any[]) => {
+  const systemPrompt = `
+      You are an expert English teacher. 
+      Analyze the user's performance in the following roleplay conversation.
+      Do not continue the roleplay. Provide feedback.
+      
+      Return ONLY a JSON object in this format:
+      {
+        "score": number (0-100 based on accuracy and fluency),
+        "grammarMistakes": [
+           { "original": "user's wrong sentence", "correction": "corrected version", "explanation": "why it is wrong" }
+        ],
+        "vocabularySuggestions": ["word1", "word2" (relevant to the topic)],
+        "overallComment": "Brief encouraging feedback"
+      }
+    `;
+  const completion = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    response_format: { type: "json_object" }, // JSON garantisi
+    messages: [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: JSON.stringify(conversationHistory) },
+    ],
+  });
+
+  const content = completion.choices[0].message.content;
+  return content ? JSON.parse(content) : null;
+};


### PR DESCRIPTION
This pull request introduces a new chat session feature for roleplay-based English learning, integrating OpenAI for conversation and feedback analysis. The implementation includes new session management endpoints, a Mongoose model for session storage, and service logic for AI interaction and feedback generation.

**Chat Session Feature Implementation**

*Controllers & Routing:*
- Added `chat.controller.ts` with endpoints to start a session, send user messages, and end a session with AI-generated feedback. Each endpoint ensures session validity and interacts with the AI service for responses and feedback.
- Registered new chat routes (`/api/chat/start`, `/api/chat/message`, `/api/chat/end`) in the Express app, protected by authentication middleware. [[1]](diffhunk://#diff-2f20385d80cb9d9b78fb05376f6cb1c3e1ca0ef404a70a95a437068859d51dbcR1-R16) [[2]](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807R5-R17)

*Session Persistence:*
- Introduced a new Mongoose model `Session` with schema for user, scenario, role, difficulty level, message history, feedback, and status. This enables persistent tracking of each chat session and its feedback.

*OpenAI Integration:*
- Created `OpenAIService.ts` with functions to get chat completions for roleplay and generate structured feedback analysis using GPT-4o. Feedback is returned as a JSON object with score, grammar mistakes, vocabulary suggestions, and an overall comment.Introduces chat session management with start, message, and end endpoints. Adds Session model, chat controller, routes, and OpenAI service for roleplay and feedback analysis. Integrates chat routes into the Express app.