### PR TITLE
feat: Add forced update check to mobile app and backend

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,8 +2,9 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import Constants from "expo-constants";
 import * as Notifications from "expo-notifications";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Platform, View } from "react-native";
 import Purchases, { LOG_LEVEL } from "react-native-purchases";
@@ -11,9 +12,11 @@ import {
   SafeAreaProvider,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import UpdateCheck from "./src/components/UpdateCheck";
 import { COLORS } from "./src/constants/color";
 import { AuthProvider, useAuth } from "./src/context/AuthContext";
 import "./src/i18n.ts";
+import { checkAppVersion } from "./src/services/api";
 // Ekranlar
 import ChatScreen from "./src/screens/ChatScreen";
 import FeedbackScreen from "./src/screens/FeedbackScreen";
@@ -216,6 +219,9 @@ Notifications.setNotificationHandler({
 });
 
 export default function App() {
+  const [requiresUpdate, setRequiresUpdate] = useState(false);
+  const [isCheckingUpdate, setIsCheckingUpdate] = useState(true);
+
   useEffect(() => {
     const initPurchases = async () => {
       // Hata ayıklama için logları açalım
@@ -228,12 +234,94 @@ export default function App() {
       }
     };
 
+    const checkVersion = async () => {
+      try {
+        // Sadece production build'lerde kontrol et
+        if (!__DEV__) {
+          const currentVersion = Constants.expoConfig?.version || "1.0.0";
+          const currentVersionCode =
+            Platform.OS === "android"
+              ? Constants.expoConfig?.android?.versionCode || 1
+              : undefined;
+
+          const versionData = await checkAppVersion();
+
+          if (versionData.requiresUpdate) {
+            // Backend'den gelen minimum sürüm ile karşılaştır
+            const minVersion = versionData.minimumVersion;
+            const minVersionCode = versionData.minimumVersionCode;
+
+            let needsUpdate = false;
+
+            if (
+              Platform.OS === "android" &&
+              minVersionCode &&
+              currentVersionCode !== undefined
+            ) {
+              // Android için versionCode karşılaştırması
+              needsUpdate = currentVersionCode < minVersionCode;
+            } else if (minVersion) {
+              // Version string karşılaştırması (örn: "1.2.4")
+              const currentParts = currentVersion.split(".").map(Number);
+              const minParts = minVersion.split(".").map(Number);
+
+              for (
+                let i = 0;
+                i < Math.max(currentParts.length, minParts.length);
+                i++
+              ) {
+                const current = currentParts[i] || 0;
+                const min = minParts[i] || 0;
+
+                if (current < min) {
+                  needsUpdate = true;
+                  break;
+                } else if (current > min) {
+                  break;
+                }
+              }
+            }
+
+            if (needsUpdate) {
+              setRequiresUpdate(true);
+            }
+          }
+        }
+      } catch (error) {
+        console.log("Version check error:", error);
+        // Hata durumunda uygulamayı açmaya devam et
+      } finally {
+        setIsCheckingUpdate(false);
+      }
+    };
+
     initPurchases();
+    checkVersion();
   }, []);
+
+  // Güncelleme kontrolü yapılırken loading göster
+  if (isCheckingUpdate && !__DEV__) {
+    return (
+      <SafeAreaProvider>
+        <View
+          style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
+        >
+          <ActivityIndicator size="large" color={COLORS.primary} />
+        </View>
+      </SafeAreaProvider>
+    );
+  }
+
   return (
     <SafeAreaProvider>
       <AuthProvider>
         <AppNavigator />
+        <UpdateCheck
+          visible={requiresUpdate}
+          onUpdate={() => {
+            // UpdateCheck component'i zaten Play Store'a yönlendiriyor
+          }}
+        />
       </AuthProvider>
     </SafeAreaProvider>
   );

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.13.2",
         "expo": "~54.0.25",
         "expo-av": "~16.0.7",
+        "expo-constants": "~18.0.12",
         "expo-dev-client": "~6.0.18",
         "expo-device": "~8.0.9",
         "expo-file-system": "^19.0.19",
@@ -1556,40 +1557,40 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.10.tgz",
-      "integrity": "sha512-lJMof5Nqakq1DxGYlghYB/ogSBjmv4Fxn1ovyDmcjlRsQdFCXgu06gEUogkhPtc9wBt9WlTTfqENln5HHyLW6w==",
+      "version": "12.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
+      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.2",
-        "@expo/config-types": "^54.0.8",
-        "@expo/json-file": "^10.0.7",
+        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "^10.0.8",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
+        "glob": "^13.0.0",
         "require-from-string": "^2.0.2",
         "resolve-from": "^5.0.0",
         "resolve-workspace-root": "^2.0.0",
         "semver": "^7.6.0",
         "slugify": "^1.3.4",
-        "sucrase": "3.35.0"
+        "sucrase": "~3.35.1"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "54.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.2.tgz",
-      "integrity": "sha512-jD4qxFcURQUVsUFGMcbo63a/AnviK8WUGard+yrdQE3ZrB/aurn68SlApjirQQLEizhjI5Ar2ufqflOBlNpyPg==",
+      "version": "54.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
+      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^54.0.8",
-        "@expo/json-file": "~10.0.7",
-        "@expo/plist": "^0.4.7",
+        "@expo/config-types": "^54.0.10",
+        "@expo/json-file": "~10.0.8",
+        "@expo/plist": "^0.4.8",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
+        "glob": "^13.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
         "slash": "^3.0.0",
@@ -1647,6 +1648,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/@expo/config-plugins/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1654,6 +1672,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/supports-color": {
@@ -1669,10 +1727,67 @@
       }
     },
     "node_modules/@expo/config-types": {
-      "version": "54.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
-      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "version": "54.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
+      "integrity": "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA==",
       "license": "MIT"
+    },
+    "node_modules/@expo/config/node_modules/glob": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+      "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "path-scurry": "^2.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/config/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@expo/config/node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/config/node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@expo/devcert": {
       "version": "1.2.0",
@@ -1786,9 +1901,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.7.tgz",
-      "integrity": "sha512-BNETbLEohk3HQ2LxwwezpG8pq+h7Fs7/vAMP3eAtFT1BCpprLYoBBFZH7gW4aqGfqOcVP4Lc91j014verrYNGg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
+      "integrity": "sha512-5VQD6GT8HIMRaSaB5JFtOXuvfDVU80YtZIuUT/GDhUF782usIXY13Tn3IdDz1Tm/lqA9qnRZQ1BF4t7LlvdJPA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -2049,9 +2164,9 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
-      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
+      "integrity": "sha512-9LOTh1PgKizD1VXfGQ88LtDH0lRwq9lsTb4aichWTWSWqy3Ugfkhfm3BhzBIkJJfQQ5iJu3m/BoRlEIjoCGcnQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
@@ -2239,9 +2354,9 @@
       }
     },
     "node_modules/@expo/plist": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
-      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
+      "integrity": "sha512-pfNtErGGzzRwHP+5+RqswzPDKkZrx+Cli0mzjQaus1ZWFsog5ibL+nVT3NcporW51o8ggnt7x813vtRbPiyOrQ==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
@@ -2477,6 +2592,27 @@
       "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
       "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
       "license": "MIT"
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -5269,13 +5405,13 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "18.0.10",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.10.tgz",
-      "integrity": "sha512-Rhtv+X974k0Cahmvx6p7ER5+pNhBC0XbP1lRviL2J1Xl4sT2FBaIuIxF/0I0CbhOsySf0ksqc5caFweAy9Ewiw==",
+      "version": "18.0.12",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.12.tgz",
+      "integrity": "sha512-WzcKYMVNRRu4NcSzfIVRD5aUQFnSpTZgXFrlWmm19xJoDa4S3/PQNi6PNTBRc49xz9h8FT7HMxRKaC8lr0gflA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~12.0.10",
-        "@expo/env": "~2.0.7"
+        "@expo/config": "~12.0.12",
+        "@expo/env": "~2.0.8"
       },
       "peerDependencies": {
         "expo": "*",
@@ -10221,17 +10357,17 @@
       "license": "MIT"
     },
     "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
-        "glob": "^10.3.10",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
         "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
         "ts-interface-checker": "^0.1.9"
       },
       "bin": {
@@ -10475,6 +10611,51 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -19,6 +19,7 @@
     "axios": "^1.13.2",
     "expo": "~54.0.25",
     "expo-av": "~16.0.7",
+    "expo-constants": "~18.0.12",
     "expo-dev-client": "~6.0.18",
     "expo-device": "~8.0.9",
     "expo-file-system": "^19.0.19",

--- a/mobile/src/components/UpdateCheck.tsx
+++ b/mobile/src/components/UpdateCheck.tsx
@@ -1,0 +1,145 @@
+import { MaterialIcons } from "@expo/vector-icons";
+import * as Linking from "expo-linking";
+import React from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { COLORS } from "../constants/color";
+
+interface UpdateCheckProps {
+  visible: boolean;
+  onUpdate: () => void;
+}
+
+const PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details?id=com.doganay.rolyai";
+const APP_STORE_URL = "https://apps.apple.com/app/idYOUR_APP_ID"; // iOS için App Store URL'inizi buraya ekleyin
+
+export default function UpdateCheck({ visible, onUpdate }: UpdateCheckProps) {
+  const { t } = useTranslation();
+
+  const handleUpdate = () => {
+    const url = Platform.OS === "android" ? PLAY_STORE_URL : APP_STORE_URL;
+    Linking.openURL(url).catch((err) => {
+      console.error("Store açılamadı:", err);
+    });
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+      onRequestClose={() => {}} // Android geri tuşunu devre dışı bırak
+    >
+      <View style={styles.overlay}>
+        <View style={styles.modalContainer}>
+          <View style={styles.iconContainer}>
+            <MaterialIcons
+              name="system-update"
+              size={64}
+              color={COLORS.primary}
+            />
+          </View>
+
+          <Text style={styles.title}>
+            {t("update_required_title", "Yeni Güncelleme Mevcut")}
+          </Text>
+
+          <Text style={styles.message}>
+            {t(
+              "update_required_message",
+              "Uygulamanın yeni bir sürümü mevcut. Devam etmek için lütfen uygulamayı güncelleyin."
+            )}
+          </Text>
+
+          <TouchableOpacity style={styles.updateButton} onPress={handleUpdate}>
+            <MaterialIcons name="download" size={24} color={COLORS.textBlack} />
+            <Text style={styles.updateButtonText}>
+              {t("update_button", "Güncelle")}
+            </Text>
+          </TouchableOpacity>
+
+          <Text style={styles.hint}>
+            {t(
+              "update_hint",
+              "Güncelleme yapıldıktan sonra uygulamayı yeniden başlatın"
+            )}
+          </Text>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: COLORS.modalOverlay,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 20,
+  },
+  modalContainer: {
+    backgroundColor: COLORS.modalBg,
+    borderRadius: 20,
+    padding: 24,
+    width: "100%",
+    maxWidth: 400,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: COLORS.borderColor,
+  },
+  iconContainer: {
+    width: 100,
+    height: 100,
+    borderRadius: 50,
+    backgroundColor: COLORS.iconBg,
+    justifyContent: "center",
+    alignItems: "center",
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: COLORS.textWhite,
+    marginBottom: 12,
+    textAlign: "center",
+  },
+  message: {
+    fontSize: 16,
+    color: COLORS.textGrey,
+    textAlign: "center",
+    marginBottom: 24,
+    lineHeight: 22,
+  },
+  updateButton: {
+    backgroundColor: COLORS.primary,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 16,
+    paddingHorizontal: 32,
+    borderRadius: 12,
+    width: "100%",
+    gap: 8,
+  },
+  updateButtonText: {
+    color: COLORS.textBlack,
+    fontSize: 18,
+    fontWeight: "bold",
+  },
+  hint: {
+    fontSize: 12,
+    color: COLORS.textGrey,
+    textAlign: "center",
+    marginTop: 16,
+    fontStyle: "italic",
+  },
+});

--- a/mobile/src/locales/en.json
+++ b/mobile/src/locales/en.json
@@ -275,6 +275,10 @@
   "leaderboard_this_week":"This week",
   "leaderboard_loading":"Loading...",
   "leaderboard_error":"Failed to load leaderboard.",
-  "learning_language":"Learning {{lang}}"
+  "learning_language":"Learning {{lang}}",
+  "update_required_title":"Update Available",
+  "update_required_message":"A new version of the app is available. Please update the app to continue.",
+  "update_button":"Update",
+  "update_hint":"Restart the app after updating"
 }
   

--- a/mobile/src/locales/tr.json
+++ b/mobile/src/locales/tr.json
@@ -274,6 +274,10 @@
   "leaderboard_this_week":"Bu hafta",
   "leaderboard_loading":"Yükleniyor...",
   "leaderboard_error":"Liderlik tablosu yüklenemedi.",
-  "learning_language":"{{lang}} Öğreniyor"
+  "learning_language":"{{lang}} Öğreniyor",
+  "update_required_title":"Yeni Güncelleme Mevcut",
+  "update_required_message":"Uygulamanın yeni bir sürümü mevcut. Devam etmek için lütfen uygulamayı güncelleyin.",
+  "update_button":"Güncelle",
+  "update_hint":"Güncelleme yapıldıktan sonra uygulamayı yeniden başlatın"
 }
   

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -165,4 +165,15 @@ export const getLeaderboard = async (type: "weekly" | "all" = "all") => {
   return response.data;
 };
 
+export const checkAppVersion = async () => {
+  try {
+    const response = await api.get("/app/version-check");
+    return response.data;
+  } catch (error: any) {
+    // Eğer endpoint yoksa veya hata varsa, güncelleme zorunlu değil
+    console.log("Version check failed:", error.message);
+    return { requiresUpdate: false };
+  }
+};
+
 export default api;

--- a/server/src/controllers/app.controller.ts
+++ b/server/src/controllers/app.controller.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from "express";
+
+/**
+ * Uygulama sürüm kontrolü endpoint'i
+ * Play Store/App Store'daki minimum gerekli sürümü döner
+ */
+export const checkAppVersion = async (req: Request, res: Response) => {
+  try {
+    // Bu değerleri environment variable'dan veya database'den alabilirsiniz
+    // Şimdilik sabit değerler kullanıyoruz
+    const minimumVersion = process.env.MINIMUM_APP_VERSION || "1.2.4";
+    const minimumVersionCode = process.env.MINIMUM_APP_VERSION_CODE
+      ? parseInt(process.env.MINIMUM_APP_VERSION_CODE, 10)
+      : 9;
+
+    // Eğer minimum sürüm belirlenmişse, güncelleme gereklidir
+    const requiresUpdate = !!minimumVersion || !!minimumVersionCode;
+
+    res.json({
+      requiresUpdate,
+      minimumVersion,
+      minimumVersionCode,
+      currentStoreVersion: minimumVersion, // Store'daki mevcut sürüm
+    });
+  } catch (error: any) {
+    console.error("Version check error:", error);
+    res.status(500).json({
+      error: "Sürüm kontrolü yapılamadı",
+      requiresUpdate: false, // Hata durumunda güncelleme zorunlu değil
+    });
+  }
+};
+

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import { connectDB } from "./config/db";
+import appRoutes from "./routes/app.route";
 import chatRoutes from "./routes/chat.route";
 import leaderboardRoutes from "./routes/leaderboard.route";
 import userRoutes from "./routes/user.route";
@@ -11,6 +12,7 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.json());
 app.use(cors());
+app.use("/api/app", appRoutes);
 app.use("/api/auth", userRoutes);
 app.use("/api/chat", chatRoutes);
 app.use("/api/words", wordRoutes);

--- a/server/src/routes/app.route.ts
+++ b/server/src/routes/app.route.ts
@@ -1,0 +1,10 @@
+import express from "express";
+import { checkAppVersion } from "../controllers/app.controller";
+
+const router = express.Router();
+
+// Sürüm kontrolü endpoint'i - authentication gerektirmez
+router.get("/version-check", checkAppVersion);
+
+export default router;
+


### PR DESCRIPTION
This pull request introduces a mandatory app update check for production builds and updates several Expo-related dependencies. The main application now checks with the backend if the current app version meets the minimum required version, and if not, prompts the user to update before proceeding. Dependency versions are also bumped to improve compatibility and security.

**App update check and user experience:**

- Added logic in `App.tsx` to check the app version against backend requirements during startup; if an update is required, the user is blocked with an update prompt using the `UpdateCheck` component. This check is only performed in production builds, and a loading indicator is shown while checking. [[1]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cR5-R19) [[2]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cR222-R224) [[3]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cR237-R324)

**Dependency updates:**

- Upgraded `expo-constants` to `~18.0.12` in both `package.json` and `package-lock.json`, and updated related dependencies such as `@expo/config`, `@expo/env`, `@expo/json-file`, `@expo/plist`, and `sucrase` to their latest compatible versions. [[1]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR19) [[2]](diffhunk://#diff-f4c98a72e8d6c80395084321af0804870bb8fbbe16ac3efbac5d86efeac0ee74R22) [[3]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL1559-R1593) [[4]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL1789-R1906) [[5]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL2052-R2169) [[6]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL2242-R2359) [[7]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL5272-R5414) [[8]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL10224-R10370)

- Added new dependencies to support updated Expo packages, including `tinyglobby`, `@isaacs/brace-expansion`, and others as required by the new versions. [[1]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR1651-R1667) [[2]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR1677-R1716) [[3]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bL1672-R1791) [[4]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR2596-R2616) [[5]](diffhunk://#diff-d5fe0185c2fabe5669a3fc3f72d11da87ac666837c125f878a81a234aedbc38bR10615-R10659)Implemented a version check mechanism in the mobile app that prompts users to update if their version is below the minimum required, using a new /app/version-check API endpoint. Added UpdateCheck component, updated translations, and created corresponding backend controller and route for version checking. Also updated dependencies to include expo-constants.