### PR TITLE
Fix/force update

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -2,10 +2,9 @@ import { MaterialIcons } from "@expo/vector-icons";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import Constants from "expo-constants";
 import * as Notifications from "expo-notifications";
 import { PostHogProvider, usePostHog } from "posthog-react-native";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 
 import { useTranslation } from "react-i18next";
 import { ActivityIndicator, Platform, View } from "react-native";
@@ -15,12 +14,10 @@ import {
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 
-import UpdateCheck from "./src/components/UpdateCheck";
 import { COLORS } from "./src/constants/color";
 import { ANALYTICS_EVENTS } from "./src/constants/events";
 import { AuthProvider, useAuth } from "./src/context/AuthContext";
 import "./src/i18n.ts";
-import { checkAppVersion } from "./src/services/api";
 import { setPostHogInstance, trackEvent } from "./src/utils/analytics";
 
 // Ekranlar
@@ -236,9 +233,6 @@ Notifications.setNotificationHandler({
 });
 
 export default function App() {
-  const [requiresUpdate, setRequiresUpdate] = useState(false);
-  const [isCheckingUpdate, setIsCheckingUpdate] = useState(true);
-
   useEffect(() => {
     const initPurchases = async () => {
       // Hata ayıklama için logları açalım
@@ -251,83 +245,8 @@ export default function App() {
       }
     };
 
-    const checkVersion = async () => {
-      try {
-        // Sadece production build'lerde kontrol et
-        if (!__DEV__) {
-          const currentVersion = Constants.expoConfig?.version || "1.0.0";
-          const currentVersionCode =
-            Platform.OS === "android"
-              ? Constants.expoConfig?.android?.versionCode || 1
-              : undefined;
-
-          const versionData = await checkAppVersion();
-
-          if (versionData.requiresUpdate) {
-            // Backend'den gelen minimum sürüm ile karşılaştır
-            const minVersion = versionData.minimumVersion;
-            const minVersionCode = versionData.minimumVersionCode;
-
-            let needsUpdate = false;
-
-            if (
-              Platform.OS === "android" &&
-              minVersionCode &&
-              currentVersionCode !== undefined
-            ) {
-              // Android için versionCode karşılaştırması
-              needsUpdate = currentVersionCode < minVersionCode;
-            } else if (minVersion) {
-              // Version string karşılaştırması (örn: "1.2.4")
-              const currentParts = currentVersion.split(".").map(Number);
-              const minParts = minVersion.split(".").map(Number);
-
-              for (
-                let i = 0;
-                i < Math.max(currentParts.length, minParts.length);
-                i++
-              ) {
-                const current = currentParts[i] || 0;
-                const min = minParts[i] || 0;
-
-                if (current < min) {
-                  needsUpdate = true;
-                  break;
-                } else if (current > min) {
-                  break;
-                }
-              }
-            }
-
-            if (needsUpdate) {
-              setRequiresUpdate(true);
-            }
-          }
-        }
-      } catch (error) {
-        console.log("Version check error:", error);
-        // Hata durumunda uygulamayı açmaya devam et
-      } finally {
-        setIsCheckingUpdate(false);
-      }
-    };
-
     initPurchases();
-    checkVersion();
   }, []);
-
-  // Güncelleme kontrolü yapılırken loading göster
-  if (isCheckingUpdate && !__DEV__) {
-    return (
-      <SafeAreaProvider>
-        <View
-          style={{ flex: 1, justifyContent: "center", alignItems: "center" }}
-        >
-          <ActivityIndicator size="large" color={COLORS.primary} />
-        </View>
-      </SafeAreaProvider>
-    );
-  }
 
   return (
     <SafeAreaProvider>
@@ -355,12 +274,6 @@ export default function App() {
         <PostHogInitializer />
         <AuthProvider>
           <AppNavigator />
-          <UpdateCheck
-            visible={requiresUpdate}
-            onUpdate={() => {
-              // UpdateCheck component'i zaten Play Store'a yönlendiriyor
-            }}
-          />
         </AuthProvider>
       </PostHogProvider>
     </SafeAreaProvider>

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "RolyAI",
     "slug": "rolyai",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -29,7 +29,7 @@
     },
     "android": {
       "package": "com.doganay.rolyai",
-      "versionCode":10,
+      "versionCode":11,
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ffffff"

--- a/mobile/src/services/api.ts
+++ b/mobile/src/services/api.ts
@@ -165,16 +165,4 @@ export const getLeaderboard = async (type: "weekly" | "all" = "all") => {
   return response.data;
 };
 
-
-export const checkAppVersion = async () => {
-  try {
-    const response = await api.get("/app/version-check");
-    return response.data;
-  } catch (error: any) {
-    // Eğer endpoint yoksa veya hata varsa, güncelleme zorunlu değil
-    console.log("Version check failed:", error.message);
-    return { requiresUpdate: false };
-  }
-};
-
 export default api;


### PR DESCRIPTION
This pull request removes the app version check and forced update logic from the mobile application, simplifying the startup process and related code. It also updates the app version and Android version code in the configuration files.

**Removal of version check and update enforcement:**

* Removed the `checkAppVersion` function from `api.ts` and all related imports and usages in `App.tsx`, eliminating the logic that checked for minimum required app version and enforced updates. [[1]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cL18-L23) [[2]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cL254-L331) [[3]](diffhunk://#diff-8a62fb3fdaaf097515fc4d9b0cd662c8d09f518f3d721ef1ff885cbab91f47e2L168-L179)
* Removed the `UpdateCheck` component and associated state from `App.tsx`, so users will no longer see a forced update screen. [[1]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cL239-L241) [[2]](diffhunk://#diff-c92a46984ef937c6501f1fa10feebdf928270c5f2fbd7fe7b24aee34812a9c2cL358-L363)

**Configuration updates:**

* Bumped the app version to `1.2.6` and Android `versionCode` to `11` in `app.json`. [[1]](diffhunk://#diff-2cdc27bcd3bf6683ad87b56ab2b3535ef12d96f91678c50004b40559f73eee22L5-R5) [[2]](diffhunk://#diff-2cdc27bcd3bf6683ad87b56ab2b3535ef12d96f91678c50004b40559f73eee22L32-R32)
[Copilot is generating a summary...]